### PR TITLE
Database authentication fails with passwords consisting only of numbers

### DIFF
--- a/lib/hoodie-app.js
+++ b/lib/hoodie-app.js
@@ -152,6 +152,8 @@ function setup() {
         throw error;
       }
       var password = npm.config.get(name + "_admin_pass") || process.env["HOODIE_ADMIN_PASS"];
+      //otherwise authentication with only digit passwords fails
+      password = password.toString();
 
       request({
         url: couch_url + "/modules",


### PR DESCRIPTION
When setting up a simple password like '12' as the admin password hoodie crashes on next start with an authentication error 
`Error: auth() received invalid user or password
    at Request.auth (/Volumes/Projects/streamz/streamz/node_modules/hoodie-app/node_modules/request/index.js:990:11)
    at Request.init (/Volumes/Projects/streamz/streamz/node_modules/hoodie-app/node_modules/request/index.js:290:10)
    at new Request (/Volumes/Projects/streamz/streamz/node_modules/hoodie-app/node_modules/request/index.js:119:8)
    at request (/Volumes/Projects/streamz/streamz/node_modules/hoodie-app/node_modules/request/index.js:1185:11)
    at EventEmitter.<anonymous> (/Volumes/Projects/streamz/streamz/node_modules/hoodie-app/lib/hoodie-app.js:156:7)
    at process._tickCallback (node.js:415:13)`

When loading the stored password in `hoodie-app:js:154` `typeof(password)` gives `number`.
When doing `password = password.toString()` `typeof(password)`will result in `string` and the authentications works.
