### PR TITLE
use ecstatic instead of connect

### DIFF
--- a/lib/hoodie-server.js
+++ b/lib/hoodie-server.js
@@ -1,5 +1,5 @@
 var cors_http = require("corsproxy");
-var static_http = require("connect/lib/middleware/static");
+var static_http = require("ecstatic");
 var url = require("url");
 var fs = require("fs");
 var os = require("os");
@@ -91,7 +91,7 @@ var hoodie_server = function(req, res, proxy) {
   //     serve ./www
   if(this.serve_static(host, this.name)) {
     console.log("[static req] %s %s", req.method, req.url);
-    static_server = static_http("./www");
+    static_server = static_http("./www", { defaultExt: 'html' });
     var that = this;
     return static_server(req, res, function() {
       handle_static_404(res, "static", that);

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.4.15",
   "dependencies": {
     "http-proxy": "*",
-    "connect": "*",
+    "ecstatic": "0.4.2",
     "corsproxy": "git://github.com/gr2m/CORS-Proxy.git",
     "multicouch": ">=0.2.8",
     "request": ">2.0.0",


### PR DESCRIPTION
this changes 2 lines of code + allows me to have links like `http://blockplot.dev/world` instead of only `http://blockplot.dev/world.html` as `ecstatic` has a `defaultExt` option: https://github.com/jesusabdullah/node-ecstatic/blob/master/lib/ecstatic.js#L74-L96

it would be best to make the ecstatic options externally configurable but I wanted to keep this simple
