### PR TITLE
Prevent couchdb admin password errors.

### DIFF
--- a/lib/hoodie-app.js
+++ b/lib/hoodie-app.js
@@ -151,6 +151,9 @@ function setup() {
         throw error;
       }
       var password = npm.config.get(name + "_admin_pass") || process.env["HOODIE_ADMIN_PASS"];
+      if(!password) {
+        throw "FATAL: No password found.";
+      }
       //otherwise authentication with only digit passwords fails
       password = password.toString();
 
@@ -197,7 +200,7 @@ function setup() {
 
           var HoodieLog = require("./hoodie-log");
           hoodie.log = new HoodieLog(name, couch_url);
-          
+
           start_workers();
         });
 
@@ -225,7 +228,11 @@ function setup() {
       output: process.stdout
     });
 
-    rl.question("Please set an admin password: ", function(password) {
+    rl.question("Please set an admin password for this app: ", function(password) {
+      if(!password) {
+        console.log("FATAL: please supply a password");
+        process.exit(1);
+      }
       installer.emit("set_password", password);
       rl.close();
     });

--- a/lib/hoodie-installer.js
+++ b/lib/hoodie-installer.js
@@ -12,7 +12,7 @@ function HoodieInstaller(name, couch_url) {
 
   var couch_has_admin = function couch_has_admin(cb) {
     // let’s request /_users
-    // if we get a 401, there is an admin
+    // if we get a 403, there is an admin
     request(couch_url + "/_users/_all_docs", function(error, response) {
       if(error !== null) {
         console.trace("couch_has_admin");


### PR DESCRIPTION
Ensure user enters an admin password & provide an error if missing. Also a tweak
to the docs (403 not 401 from couchdb). I found these becuase entered an admin
password I didn't want to use so removed it from npm config, which killed
hoodie start.
