### PR TITLE
support for couch db installed via macports

### DIFF
--- a/lib/environment.js
+++ b/lib/environment.js
@@ -117,6 +117,10 @@ exports.getCouch = function (env) {
         cfg.couch.bin = '/usr/local/bin/couchdb';
         cfg.couch.default_ini = '/usr/local/etc/couchdb/default.ini';
     }
+    else if (fs.existsSync('/opt/local/bin/couchdb')) {
+        cfg.couch.bin = '/opt/local/bin/couchdb';
+        cfg.couch.default_ini = '/opt/local/etc/couchdb/default.ini';
+    }
     else if (fs.existsSync('/usr/bin/couchdb')) {
         cfg.couch.bin = '/usr/bin/couchdb';
         cfg.couch.default_ini = '/etc/couchdb/default.ini';


### PR DESCRIPTION
macports has couchdb by default installed into /opt/local/bin/couchdb
with the default configuration in /opt/local/etc/couchdb/default.ini
