### PR TITLE
Fix npm issues (node 0.10.x, npm 1.2.20)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,10 @@
 {
     "name": "hoodie-app",
     "version": "0.5.0",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/hoodiehq/hoodie-app.git"
+    },
     "dependencies": {
         "http-proxy": "*",
         "connect": "2.7.4",
@@ -26,7 +30,7 @@
         "test": "mocha"
     },
     "engines": {
-        "node": "0.8.x"
+        "node": ">=0.8.x"
     },
     "devDependencies": {
         "mocha": "*"


### PR DESCRIPTION
Running `hoodie new myapp` throws two npm warnings:

```
npm WARN package.json hoodie-app@0.5.0 No repository field.
npm WARN engine hoodie-app@0.5.0: wanted: {"node":"0.8.x"} (current: {"node":"v0.10.7","npm":"1.2.21"})
```

The repository field was introduced in [npm 1.2.20](https://github.com/isaacs/npm/issues/3446), and setting the engine >= 0.8.x allows it to run also on newer node versions.
