### PR TITLE
Don't use mkdir -p

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,5 +1,5 @@
 var open = require('open');
-var child_process = require('child_process');
+var mkdirp = require('mkdirp');
 
 
 /**
@@ -11,17 +11,7 @@ var child_process = require('child_process');
  */
 
 exports.ensureDir = function (path, callback) {
-    var mkdir = child_process.spawn('mkdir', ['-p', path]);
-    var err_data = '';
-    mkdir.stderr.on('data', function (data) {
-        err_data += data.toString();
-    });
-    mkdir.on('exit', function (code) {
-        if (code !== 0) {
-            return callback(new Error(err_data));
-        }
-        callback();
-    });
+    mkdirp(path, callback);
 };
 
 /**

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
         "send": "0.1.0",
         "optimist": "0.5.0",
         "ports": ">=1.0.0",
-        "open":"*"
+        "open":"*",
+        "mkdirp": "0.3.5"
     },
     "scripts": {
         "start": "bin/start",


### PR DESCRIPTION
A quick fix for support on Windows because `mkdir -p` creates a dir called `-p`!
