### PR TITLE
fix for nodejitsu hosting -- couchdb url param not being properly set after yesterday's changes.

### DIFF
--- a/lib/environment.js
+++ b/lib/environment.js
@@ -127,6 +127,7 @@ exports.getCouch = function (env) {
 
     if (env.COUCH_URL) {
         // using remote couchdb
+        cfg.couch.url = env.COUCH_URL;
         cfg.couch.run = false;
         return cfg;
     }


### PR DESCRIPTION
I've verified that this is why nodejitsu hosting was broken for me today. 
