### PR TITLE
misleading comment

### DIFF
--- a/lib/plugins.js
+++ b/lib/plugins.js
@@ -102,7 +102,7 @@ exports.hasWorker = function (path) {
 
 /**
  * Finds all the dependencies in the app's package.json which
- * start with 'plugin-'
+ * start with 'hoodie-plugin-'
  */
 
 exports.getPluginModuleNames = function (pkg) {


### PR DESCRIPTION
comment misleadingly informed us that 'plugin-' would be the prefix used for finding hoodie plugins, when it is indeed 'hoodie-plugin-'.

BTW, I very much like this approach for installing plugins.
