### PR TITLE
misleading comment

### DIFF
--- a/lib/plugins.js
+++ b/lib/plugins.js
@@ -102,7 +102,7 @@ exports.hasWorker = function (path) {
 
 /**
  * Finds all the dependencies in the app's package.json which
- * start with 'plugin-'
+ * start with 'hoodie-plugin-'
  */
 
 exports.getPluginModuleNames = function (pkg) {
@@ -121,7 +121,7 @@ exports.pluginModuleToName = function (mod) {
 
 /**
  * Finds all the dependencies in the app's package.json which
- * start with 'plugin-' and returns them with the hoodie-plugin part
+ * start with 'hoodie-plugin-' and returns them with the hoodie-plugin part
  * of the name removed
  */
 


### PR DESCRIPTION
comment misleadingly informed us that 'plugin-' would be the prefix used for finding hoodie plugins, when it is indeed 'hoodie-plugin-'.
