### PR TITLE
Small tweak to make it clear what is being started

### DIFF
--- a/lib/plugins.js
+++ b/lib/plugins.js
@@ -60,7 +60,7 @@ exports.startPlugin = function (name, project_dir, hoodie, callback) {
   var p = exports.path(name, project_dir);
 
   if (exports.hasWorker(p)) {
-    console.log('Starting: \'%s\'', name);
+    console.log('Starting Plugin: \'%s\'', name);
     var wmodule = require(p);
     return wmodule(hoodie, callback);
   }


### PR DESCRIPTION
Without the word plugin before the label, it woudld be difficult for someone unfamiliar with hoodie to know what was starting. Alternatively to this, you could just say "Starting Plugins" before you started starting plugins.

Ignore this if it's too pedantic of course.
