### PR TITLE
load hoodie.js from git / custom branch

### DIFF
--- a/lib/middleware/serve_hoodie.js
+++ b/lib/middleware/serve_hoodie.js
@@ -25,16 +25,18 @@ module.exports = function (config) {
   });
 
   var extensions = paths.filter(fs.existsSync).map(readString);
-  var hoodie_dir = path.resolve(__dirname, '../../node_modules/hoodie/dist');
+  var hoodie_path = path.resolve(
+    __dirname, '../../node_modules/hoodie/dist/hoodie.js'
+  );
 
   // if the user's project has defined a hoodie.js dependency,
   // then favour that over our own dependency.
-  if (config.app.dependencies.hoodie) {
-    hoodie_dir = path.resolve(config.project_dir, 'node_modules/hoodie/dist');
-    console.log('loading alternative hoodie.js from %s', hoodie_dir);
+  if (config.app.hoodie && config.app.hoodie.hoodiejs) {
+    hoodie_path = path.resolve(config.project_dir, config.app.hoodie.hoodiejs);
+    console.log('Loading alternative hoodie.js from %s', hoodie_path);
   }
 
-  var base = readString(hoodie_dir + '/hoodie.js');
+  var base = readString(hoodie_path);
   var hoodiejs = base + extensions.join('\n');
 
   return dispatch({


### PR DESCRIPTION
use case:
I have a hoodie app and run into a problem with hoodie.js. I fix it and push it to github as a new branch or fork. Now, I'd like to have hoodie-server serve my custom hoodie.js version instead of the one specified in its `package.json`

Is there a way to do that?
