### PR TITLE
Allow prompt-less first-time setup of admin users via ENV var

### DIFF
--- a/lib/environment.js
+++ b/lib/environment.js
@@ -91,6 +91,10 @@ exports.getConfig = function (platform, env, project_dir, argv) {
     cfg.couch.port = ports.getPort(cfg.id + '-couch');
   }
 
+  if (process.env.HOODIE_SETUP_PASSWORD) {
+    cfg.admin_password = process.env.HOODIE_SETUP_PASSWORD;
+  }
+
   if (process.env.CI) {
     cfg.open_browser = false;
   }


### PR DESCRIPTION
Set `HOODIE_SETUP_PASSWORD` in the environment before running
`hoodie start` for the first time to use that password for the
Hoodie admin user.

---

This commit was sponsored by Human JavaScript.
Human JavaScript is the best way to learn modern
web application development today, read it now:

http://go.hood.ie/human-javascript
