### PR TITLE
Windows couchdb probing to enviornment.js (fixes #86)

### DIFF
--- a/lib/environment.js
+++ b/lib/environment.js
@@ -148,6 +148,9 @@ exports.getCouch = function (env) {
   } else if (fs.existsSync('/usr/bin/couchdb')) {
     cfg.couch.bin = '/usr/bin/couchdb';
     cfg.couch.default_ini = '/etc/couchdb/default.ini';
+  } else if (fs.existsSync('C:\\Program Files (x86)\\Apache Software Foundation\\CouchDB')) {
+    cfg.couch.bin = 'C:\\Program Files (x86)\\Apache Software Foundation\\CouchDB\\couchdb.bat';
+    cfg.couch.default_ini = 'C:\\Program Files (x86)\\Apache Software Foundation\\CouchDB\\default.ini';
   }
   // override if environment vars set
   if (env.COUCH_BIN) {


### PR DESCRIPTION
Added windows probing to enviornment.js, I was experiencing "no couchdb binary found" and "no couchdb default.ini found".
