### PR TITLE
fix for #215 “nodejitsu deploy not working anymore”, will create pull-re...

### DIFF
--- a/lib/core/environment.js
+++ b/lib/core/environment.js
@@ -97,7 +97,7 @@ exports.getConfig = function (platform, env, project_dir, argv) {
       throw new Error('HOODIE_ADMIN_PASS environment variable not set');
     }
 
-    _.extend(cfg, {
+    _.defaults(cfg, {
       // Nodejitsu config
       host: '0.0.0.0',
       domain: 'jit.su',


### PR DESCRIPTION
fix for #215 `cfg` didn't get extended for `cfg.couch`, but rather the destination member `couch`  was overwritten 
