### PR TITLE
Fix broken paths on windows

### DIFF
--- a/lib/core/environment.js
+++ b/lib/core/environment.js
@@ -20,6 +20,9 @@ var utils = require('../utils');
 
 exports.getConfig = function (platform, env, project_dir, argv) {
   
+  // Remove driver letter on windows
+  project_dir = '/' + path.relative('/', project_dir);
+  
   // location of project's package.json
   var pkgfile = require(project_dir + '/package.json');
 
@@ -30,8 +33,8 @@ exports.getConfig = function (platform, env, project_dir, argv) {
       return path.resolve(project_dir, '' + this.www_root + '/index.html');
     },
     project_dir: project_dir,
-    www_root: '/' + path.relative('/', project_dir + '/www'),
-    admin_root: '/' + path.relative('/', project_dir + '/node_modules/hoodie-server/node_modules/hoodie-pocket/www'),
+    www_root: project_dir + '/www',
+    admin_root: project_dir + '/node_modules/hoodie-server/node_modules/hoodie-pocket/www',
     host: process.env.HOODIE_BIND_ADDRESS || '127.0.0.1',
     app: pkgfile,
     domain: 'dev',

--- a/lib/helpers/plugin_api.js
+++ b/lib/helpers/plugin_api.js
@@ -26,7 +26,7 @@ exports.pockets = function (config) {
     var plugin = config.plugins[id];
     var name = plugin.metadata.name.replace(/^hoodie-plugin-/, '');
 
-    acc[name] = '/' + path.relative('/', path.resolve(config.project_dir, 'node_modules', plugin.path, 'pocket'));
+    acc[name] = path.resolve(config.project_dir, 'node_modules', plugin.path, 'pocket');
 
     return acc;
   }, {});

--- a/lib/server/plugins/admin/index.js
+++ b/lib/server/plugins/admin/index.js
@@ -1,5 +1,3 @@
-var path = require('path');
-
 exports.register = function (plugin, options, next) {
 
   'use strict';
@@ -10,7 +8,7 @@ exports.register = function (plugin, options, next) {
       path: '/{p*}',
       handler: {
         directory: {
-          path: path.relative(__dirname, options.admin_root),
+          path: options.admin_root,
           listing: false,
           index: true
         }

--- a/lib/server/plugins/api/index.js
+++ b/lib/server/plugins/api/index.js
@@ -1,5 +1,4 @@
 var _ = require('underscore');
-var path = require('path');
 
 var hoodiejs = require('../../../helpers/pack_hoodie');
 var plugins = require('../../../helpers/plugin_api');
@@ -103,7 +102,7 @@ exports.register = function (plugin, options, next) {
       handler: {
         directory: {
           path: function (request) {
-            return path.relative(__dirname, plugins.pockets(options.app)[request.params.name]);
+            return plugins.pockets(options.app)[request.params.name];
           },
           listing: false,
           index: true

--- a/lib/server/plugins/web/index.js
+++ b/lib/server/plugins/web/index.js
@@ -1,5 +1,3 @@
-var path = require('path');
-
 exports.register = function (plugin, options, next) {
 
   'use strict';
@@ -10,7 +8,7 @@ exports.register = function (plugin, options, next) {
       path: '/{p*}',
       handler: {
         directory: {
-          path: path.relative(__dirname, options.www_root),
+          path: options.www_root,
           listing: false,
           index: true
         }


### PR DESCRIPTION
On windows the path option will contain a driver letter, e.g. "C:\User\hoodie". Such paths can't be handled by Hapi (I don't know any server framework which handles these the correct way) what results in a 404 response. Using a relative path (e.g. "../../www") this issue is solved.
