### PR TITLE
Announce all plugins when starting, not just those with a worker

### DIFF
--- a/lib/core/plugins.js
+++ b/lib/core/plugins.js
@@ -70,8 +70,8 @@ exports.startAll = function (cfg, callback) {
 
 exports.startPlugin = function (name, cfg, hoodie, callback) {
   var p = cfg.plugins[name].path;
+  console.log('Starting Plugin: \'%s\'', name);
   if (exports.hasWorker(p)) {
-    console.log('Starting Plugin: \'%s\'', name);
     var wmodule = require(p);
     return wmodule(hoodie, callback);
   }


### PR DESCRIPTION
This is a very silly commit, but does solve issue #152 ;-)
