### PR TITLE
[fix] Path to plugin assets directory

### DIFF
--- a/lib/server/plugins/api/index.js
+++ b/lib/server/plugins/api/index.js
@@ -116,7 +116,7 @@ exports.register = function (plugin, options, next) {
       path: '/_api/_plugins/_assets/{path*}',
       handler: {
         directory: {
-          path: options.app.project_dir + '/node_modules/hoodie-pocket-uikit/app',
+          path: options.app.project_dir + '/node_modules/hoodie-server/node_modules/hoodie-pocket-uikit/app',
           listing: true,
           index: false
         }


### PR DESCRIPTION
The path to the assets directory actually didn't work in a proper dev setting.

cc. @janl @svnlto 
