### PR TITLE
Replace node-http-proxy with hapi server

### DIFF
--- a/lib/server/nodejitsu_server.js
+++ b/lib/server/nodejitsu_server.js
@@ -2,8 +2,7 @@
  * Creates a proxy server to handle nodejitsu requests based on subdomain
  */
 
-var http = require('http');
-var httpProxy = require('http-proxy');
+var Hapi = require('hapi');
 
 module.exports = function (config, callback) {
 
@@ -12,28 +11,39 @@ module.exports = function (config, callback) {
     return callback();
   }
 
-  var proxy = httpProxy.createProxyServer({});
+  var server = new Hapi.Server(8080, {
+    cors: true,
+    labels: [ 'nodejitsu' ]
+  });
 
-  return http.createServer(function (req, res) {
+  function mapProxyPath(req, cb) {
     var host = req.headers.host;
     var subdomain = host.split('.')[0];
-    var options = { target: 'http://' + config.host + ':' };
+    var target = 'http://' + config.host + ':';
 
-    switch (subdomain) {
-    case 'admin':
-      options.target += config.admin_port;
-      break;
-    case 'couch':
-      options.target = config.couch.url;
-      break;
-    default:
-      options.target += config.www_port;
-      break;
+    if (subdomain === 'admin') {
+      target += config.admin_port;
+    } else if (subdomain === 'couch') {
+      target = config.couch.url;
+    } else {
+      target += config.www_port;
     }
 
-    proxy.web(req, res, options);
+    cb(null, target + req.url.path);
+  }
 
-  }).listen(80, config.host, callback);
+  server.route({
+    path: '/{p*}',
+    method: '*',
+    handler: {
+      proxy: {
+        passThrough: true,
+        mapUri: mapProxyPath
+      }
+    }
+  });
+
+  server.start(callback);
 
 };
 

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "ports": "1.1.0",
     "mkdirp": "0.3.5",
     "hapi": "2.4.0",
-    "http-proxy": "1.0.2",
     "lodash": "^2.4.1",
     "browserify": "^3.30.2",
     "watch": "^0.9.0"


### PR DESCRIPTION
This simplifies things and allows us to get rid of `http-proxy` as a dependency. `Hapi` is already being used for the `www` and `admin` servers, so it seems cleaner to just use it for the nodejitsu proxy instead of bringing in yet another module.
