### PR TITLE
Update required node version

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "test": "grunt test --verbose"
   },
   "engines": {
-    "node": ">=0.10.x"
+    "node": ">=0.10.22"
   },
   "devDependencies": {
     "mocha": "*",


### PR DESCRIPTION
Note: [hapi](https://github.com/spumko/hapi) requires node >= 0.10.22 since version 3.0.0

See also https://github.com/spumko/hapi/commit/7743419614d0c1b59f0c494acc1acab27234e956

Using node >= 0.10.22 solves also an issue occurring at server start:

```
hoodie-server/node_modules/hapi/lib/schema.js:182 expiresIn:
    Joi.number().xor('expiresAt'),

TypeError: Object [object Object] has no method 'xor'
```
