### PR TITLE
Add 'www' option to start script usage (help)

### DIFF
--- a/bin/start
+++ b/bin/start
@@ -11,11 +11,13 @@ var app = require('../lib');
 
 // parse command-line arguments
 var argv = require('optimist')
-  .alias('h', 'help')
-  .describe('help', 'Show usage information')
+  .usage('Usage: $0 [options]')
+  .alias('w', 'www')
+  .describe('www', 'Set www root directory')
   .describe('local-tld', 'Turn on local-tld on supported platforms')
   .describe('no-local-tld', 'Turn off local-tld on supported platforms')
-  .usage('Usage: start [options]')
+  .alias('h', 'help')
+  .describe('help', 'Show usage information')
   .argv;
 
 /**


### PR DESCRIPTION
I noticed there is a `www` option that can be passed into the `start` script but although it works it didn't show up in the usage text. This is just a minor enhancement so that running `./bin/start -h` shows the `www` option as follows.

```
Usage: node ./bin/start [options]

Options:
  --www, -w       Set www root directory
  --local-tld     Turn on local-tld on supported platforms
  --no-local-tld  Turn off local-tld on supported platforms
  --help, -h      Show usage information
```
