### PR TITLE
fix(api): return 404 for /_api/_all_dbs

### DIFF
--- a/lib/server/plugins/api/index.js
+++ b/lib/server/plugins/api/index.js
@@ -44,6 +44,11 @@ exports.register = function (plugin, options, next) {
   plugin.route([
     {
       method: 'GET',
+      path: '/_api/_all_dbs',
+      handler: internals.notFound
+    },
+    {
+      method: 'GET',
       path: '/_api/{p*}',
       handler: {
         proxy: {

--- a/test/integration/block-all-dbs.js
+++ b/test/integration/block-all-dbs.js
@@ -1,0 +1,32 @@
+var expect = require('expect.js');
+var hoodie_server = require('../../');
+var http = require('http');
+var os = require('os');
+
+var config = {
+  www_port: 5051,
+  admin_port: 5061,
+  admin_password: '12345'
+};
+
+describe('block _all_dbs', function () {
+
+  before(function (done) {
+    hoodie_server.start(config, done);
+  });
+
+  // TODO: I guess we should kill the server once we are done with the tests
+  //after(function (done) {});
+
+  it('should 404 on /_api/_all_dbs', function (done) {
+    http.get({
+      host: '127.0.0.1',
+      port: config.www_port,
+      method: 'get',
+      path: '/_api/_all_dbs',
+    }, function (res) {
+      expect(res.statusCode).to.be(404);
+      done();
+    });
+  });
+});

--- a/test/runner.js
+++ b/test/runner.js
@@ -15,3 +15,4 @@ require('./unit/helpers-pack_hoodie-test');
 require('./integration/require');
 require('./integration/handle_404');
 require('./integration/assets');
+require('./integration/block-all-dbs');


### PR DESCRIPTION
Hoodie considers database names private and CouchDB doesn’t. Hence
this special handler to avoid leaking unwanted information.
