### PR TITLE
feat(requests): allow request sizes up to 10 MB

### DIFF
--- a/lib/server/index.js
+++ b/lib/server/index.js
@@ -14,12 +14,18 @@ module.exports = function () {
 
     pack.server(env_config.www_port, {
       labels: ['web'],
-      cors: true
+      cors: true,
+      payload: {
+        maxBytes: 1048576 * 10 // 10 MB
+      }
     });
 
     pack.server(env_config.admin_port, {
       labels: ['admin'],
-      cors: true
+      cors: true,
+      payload: {
+        maxBytes: 1048576 * 10 // 10 MB
+      }
     });
 
     var hapi_plugins = [


### PR DESCRIPTION
This should sove any problems with replicating attachments up to
10 MB.

This should probably an app config setting at some point.
