### PR TITLE
Fix paths windows

### DIFF
--- a/lib/core/environment.js
+++ b/lib/core/environment.js
@@ -34,9 +34,6 @@ var get_admin_root = function (project_dir) {
 
 exports.getConfig = function (platform, env, cwd, argv) {
 
-  // Remove driver letter on windows
-  cwd = '/' + path.relative('/', cwd);
-
   // location of project's package.json
   var pkgfile = require(cwd + '/package.json');
   var hoodie_admin_dashboard_root = get_admin_root(cwd);

--- a/test/integration/handle_404.js
+++ b/test/integration/handle_404.js
@@ -1,7 +1,6 @@
 var expect = require('expect.js');
 var hoodie_server = require('../../');
 var http = require('http');
-var os = require('os');
 
 var config = {
   www_port: 5011,
@@ -30,9 +29,9 @@ describe('handle 404', function () {
       }
     }, function (res) {
       var buf = '';
-      res.on('data', function (chunk) { buf += chunk});
+      res.on('data', function (chunk) { buf += chunk; });
       res.on('end', function () {
-        expect(buf).to.be('hi' + os.EOL);
+        expect(buf).to.be('hi\n');
         done();
       });
     });
@@ -50,7 +49,7 @@ describe('handle 404', function () {
       }
     }, function (res) {
       var buf = '';
-      res.on('data', function (chunk) { buf += chunk});
+      res.on('data', function (chunk) { buf += chunk; });
       res.on('end', function () {
         buf = JSON.parse(buf);
         expect(buf.statusCode).to.be(404);


### PR DESCRIPTION
this fixes the unusable admin-dashboard on windows. without the drive letter, hapi did not correctly served the asset files.

testet it with `grunt test` and in on of my projects. further testing is required.