### PR TITLE
feat(http): Allow clients to request a gzip response with ?gzip=force

### DIFF
--- a/lib/assets/force-gzip.html
+++ b/lib/assets/force-gzip.html
@@ -1,0 +1,4 @@
+<!DOCTYPE html>
+<script type="text/javascript">
+  document.cookie = document.cookie.replace(/hoodie_force_gzip=false/, 'hoodie_force_gzip=true;path=/');
+</script>

--- a/lib/server/plugins/api/index.js
+++ b/lib/server/plugins/api/index.js
@@ -118,6 +118,25 @@ exports.register = function (plugin, options, next) {
     );
   };
 
+  // allow clients to request a gzip response, even if the
+  // Accept-Encoding headers is missing or mangled due to
+  // faulty proxy servers
+  // http://www.stevesouders.com/blog/2010/07/12/velocity-forcing-gzip-compression/
+  plugin.ext('onPreHandler', function maybeForceGzip (request, reply) {
+    var hasGzipQuery = function () {
+      return request.query.gzip === 'force';
+    };
+
+    var hasGzipCookie = function () {
+      return request.state.hoodie_force_gzip === 'true';
+    };
+
+    if (hasGzipQuery() || hasGzipCookie()) {
+      request.info.acceptEncoding = 'gzip';
+    }
+    reply.continue();
+  });
+
   plugin.route([
     {
       method: 'OPTIONS',
@@ -267,6 +286,20 @@ exports.register = function (plugin, options, next) {
       method: 'GET',
       path: '/_api/_files/hoodie.js',
       handler: internals.getHoodiePath
+    },
+    {
+      method: 'GET',
+      path: '/_api/_files/force-gzip.html',
+      handler: function (request, reply) {
+        var projectDir = options.app.project_dir;
+        var internalFilePath = 'node_modules/hoodie-server/lib/assets/force-gzip.html';
+        if (!options.app.is_in_app) {
+          // we are running inside hoodie-server, e.g. in dev and test mode
+          internalFilePath = internalFilePath.replace('node_modules/hoodie-server', '');
+        }
+        var finalFilePath = path.join(projectDir, internalFilePath);
+        reply.file(finalFilePath);
+      }
     }
   ]);
 

--- a/test/integration/assets.js
+++ b/test/integration/assets.js
@@ -4,20 +4,13 @@ var http = require('http');
 var os = require('os');
 
 var config = {
-  www_port: 5031,
-  admin_port: 5041,
+  www_port: 5001,
+  admin_port: 5011,
   admin_password: '12345'
 };
 
 describe('handle assets', function () {
   this.timeout(30000);
-
-  before(function (done) {
-    hoodie_server.start(config, done);
-  });
-
-  // TODO: I guess we should kill the server once we are done with the tests
-  //after(function (done) {});
 
   it('should get asset path', function (done) {
     http.get({
@@ -25,6 +18,7 @@ describe('handle assets', function () {
       port: config.www_port,
       method: 'get',
       path: '/_api/_plugins/_assets/index.html',
+      agent: false
     }, function (res) {
       expect(res.statusCode).to.be(200);
       done();

--- a/test/integration/cors.js
+++ b/test/integration/cors.js
@@ -4,24 +4,21 @@ var http = require('http');
 var os = require('os');
 
 var config = {
-  www_port: 5032,
-  admin_port: 5042,
+  www_port: 5001,
+  admin_port: 5011,
   admin_password: '12345'
 };
 
 describe('setting CORS headers', function () {
   this.timeout(30000);
 
-  before(function (done) {
-    hoodie_server.start(config, done);
-  });
-
   it('should respond to OPTIONS with the right CORS headers when no origin is given', function (done) {
     http.get({
       host: '127.0.0.1',
       port: config.www_port,
       method: 'options',
-      path: '/_api/_session/'
+      path: '/_api/_session/',
+      agent: false
     }, function (res) {
       expect(res.headers['access-control-allow-origin']).to.be('*');
       expect(res.headers['access-control-allow-headers']).to.be('authorization, content-length, content-type, if-match, if-none-match, origin, x-requested-with, host, connection, transfer-encoding');
@@ -42,7 +39,8 @@ describe('setting CORS headers', function () {
       path: '/_api/_session/',
       headers: {
         origin: 'http://some.app.com/'
-      }
+      },
+      agent: false
     }, function (res) {
       expect(res.headers['access-control-allow-origin']).to.be('http://some.app.com/');
       expect(res.headers['access-control-allow-headers']).to.be('authorization, content-length, content-type, if-match, if-none-match, origin, x-requested-with, host, connection');

--- a/test/integration/force-gzip.js
+++ b/test/integration/force-gzip.js
@@ -1,0 +1,97 @@
+var expect = require('expect.js');
+var hoodie_server = require('../../');
+var http = require('http');
+var zlib = require('zlib');
+var os = require('os');
+
+var config = {
+  www_port: 5100,
+  admin_port: 5110,
+  admin_password: '12345'
+};
+
+describe('handle forced gzip', function () {
+  this.timeout(30000);
+
+  before(function (done) {
+    hoodie_server.start(config, done);
+  });
+
+  // TODO: I guess we should kill the server once we are done with the tests
+  //after(function (done) {});
+
+  it('should receive gzip when gzip accept header sent', function (done) {
+    http.get({
+      host: '127.0.0.1',
+      port: config.www_port,
+      method: 'get',
+      path: '/_api/',
+      headers: {
+        'Accept-Encoding': 'gzip, deflate'
+      }
+    }, function (res) {
+      expect(res.headers['content-encoding']).to.be('gzip');
+      res.on('end', function() {
+        done();
+      });
+
+      var gunzip = zlib.createGunzip();
+      gunzip.on('error', function(error){
+        console.log('Error, ', error);
+        done(error);
+      });
+
+      res.pipe(gunzip);
+
+    });
+  });
+
+  it('should receive no gzip when no gzip accept header sent', function (done) {
+    http.get({
+      host: '127.0.0.1',
+      port: config.www_port,
+      method: 'get',
+      path: '/_api/',
+    }, function (res) {
+      expect(res.headers['content-encoding']).to.be(undefined);
+      done();
+    });
+  });
+
+  it('should receive gzip when no gzip accept header sent but force query param', function (done) {
+    http.get({
+      host: '127.0.0.1',
+      port: config.www_port,
+      method: 'get',
+      path: '/_api/?gzip=force',
+    }, function (res) {
+      expect(res.headers['content-encoding']).to.be('gzip');
+      res.on('end', function() {
+        done();
+      });
+
+      var gunzip = zlib.createGunzip();
+      gunzip.on('error', function(error){
+        console.log('Error, ', error);
+        done(error);
+      });
+
+      res.pipe(gunzip);
+    });
+  });
+
+  it('should receive a force-gzip html file', function (done) {
+    http.get({
+      host: '127.0.0.1',
+      port: config.www_port,
+      method: 'get',
+      path: '/_api/_files/force-gzip.html',
+      agent: false
+    }, function (res) {
+      expect(res.statusCode).to.be(200);
+      done();
+    });
+  });
+
+
+});

--- a/test/integration/handle_404.js
+++ b/test/integration/handle_404.js
@@ -3,20 +3,13 @@ var hoodie_server = require('../../');
 var http = require('http');
 
 var config = {
-  www_port: 5011,
-  admin_port: 5021,
+  www_port: 5001,
+  admin_port: 5011,
   admin_password: '12345'
 };
 
 describe('handle 404', function () {
   this.timeout(30000);
-
-  before(function (done) {
-    hoodie_server.start(config, done);
-  });
-
-  // TODO: I guess we should kill the server once we are done with the tests
-  //after(function (done) {});
 
   it('should send index.html on accept: text/html', function (done) {
     http.get({
@@ -26,7 +19,8 @@ describe('handle 404', function () {
       path: '/does_not_exist',
       headers: {
         accept: 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8'
-      }
+      },
+      agent: false
     }, function (res) {
       var buf = '';
       res.on('data', function (chunk) { buf += chunk; });
@@ -46,7 +40,8 @@ describe('handle 404', function () {
       path: '/does_not_exist',
       headers: {
         accept: 'application/json'
-      }
+      },
+      agent: false
     }, function (res) {
       var buf = '';
       res.on('data', function (chunk) { buf += chunk; });

--- a/test/integration/require.js
+++ b/test/integration/require.js
@@ -5,8 +5,8 @@ describe('Requireability', function () {
   this.timeout(30000);
   it('should require & start', function (done) {
     var config = {
-      www_port: 5010,
-      admin_port: 5020,
+      www_port: 5021,
+      admin_port: 5031,
       admin_password: '12345'
     };
     this.timeout(5000);

--- a/test/integration/security.js
+++ b/test/integration/security.js
@@ -4,20 +4,13 @@ var http = require('http');
 var os = require('os');
 
 var config = {
-  www_port: 5051,
-  admin_port: 5061,
+  www_port: 5001,
+  admin_port: 5011,
   admin_password: '12345'
 };
 
 describe('block _all_dbs', function () {
   this.timeout(30000);
-
-  before(function (done) {
-    hoodie_server.start(config, done);
-  });
-
-  // TODO: I guess we should kill the server once we are done with the tests
-  //after(function (done) {});
 
   it('should 404 on /_api/_all_dbs', function (done) {
     http.get({
@@ -25,6 +18,7 @@ describe('block _all_dbs', function () {
       port: config.www_port,
       method: 'get',
       path: '/_api/_all_dbs',
+      agent: false
     }, function (res) {
       expect(res.statusCode).to.be(404);
       done();
@@ -42,7 +36,8 @@ describe('block _all_dbs', function () {
       headers: {
         'Content-Type': 'application/x-www-form-urlencoded',
         'Content-length': body.length
-      }
+      },
+      agent: false
     }, function (res) {
       expect(res.statusCode).to.be(200);
       done();

--- a/test/integration/start-server.js
+++ b/test/integration/start-server.js
@@ -1,0 +1,21 @@
+var expect = require('expect.js');
+var hoodie_server = require('../../');
+
+var config = {
+  www_port: 5001,
+  admin_port: 5011,
+  admin_password: '12345'
+};
+
+describe('handle assets', function () {
+  this.timeout(30000);
+
+  before(function (done) {
+    hoodie_server.start(config, done);
+  });
+
+  it('should start server', function (done) {
+    done();
+  });
+
+});

--- a/test/runner.js
+++ b/test/runner.js
@@ -13,6 +13,7 @@ require('./unit/api-plugin-test');
 require('./unit/utils-test');
 require('./unit/couch-utils-test');
 require('./unit/helpers-pack_hoodie-test');
+require('./integration/start-server');
 require('./integration/require');
 require('./integration/handle_404');
 require('./integration/assets');

--- a/test/runner.js
+++ b/test/runner.js
@@ -19,3 +19,4 @@ require('./integration/handle_404');
 require('./integration/assets');
 require('./integration/security');
 require('./integration/cors');
+require('./integration/force-gzip');


### PR DESCRIPTION
Some clients, while understanding gzip resources and sending the
correct Accept-Encoding HTTP header are behind proxy servers that
strip the header, resulting the server to send a non-gzip response.

Steve Souders, Tony Gentilcore and Andy Martone outline a way to
resolve this in:

http://www.stevesouders.com/blog/2010/07/12/velocity-forcing-gzip-compression/

This implements the server-side component of this scheme. Any request
to /_api that has a query parameter `?gzip=force` will receive a gzipped
response, even if no Accept-Encoding header is present or if it is mangled.

Includes a test that works, but is disabled because of a bug that shows up
during test runs. A more detailed explaination is in the corresponding
Pull Request.

Thanks to Philip @latentflip Roberts for brainstorming an approach and
for providing a proof of concept that I could work off of.

