### PR TITLE
Find files of dependencies with `require.resolve` to be dedupe save

### DIFF
--- a/lib/core/environment.js
+++ b/lib/core/environment.js
@@ -13,38 +13,22 @@ var path = require('path');
 var utils = require('../utils');
 var couchUtils = require('../utils/couch');
 
-
 /**
  * Returns all config values for current environment
  */
-
-var is_in_app = function(project_dir) {
-  return ! /hoodie-server$/.test(project_dir);
-};
-
-var get_admin_root = function (project_dir) {
-  if (!is_in_app(project_dir)) {
-    // we run in hoodie-server raw mode
-    return '/node_modules/hoodie-admin-dashboard/www';
-  }
-
-  // normal in-app startup
-  return '/node_modules/hoodie-server/node_modules/hoodie-admin-dashboard/www';
-};
 
 exports.getConfig = function (platform, env, cwd, argv) {
 
   // location of project's package.json
   var pkgfile = require(cwd + '/package.json');
-  var hoodie_admin_dashboard_root = get_admin_root(cwd);
 
   // default platform-agnostic config
   var env_config = {
-    is_in_app: is_in_app(cwd),
+    is_in_app: !/hoodie-server$/.test(cwd),
     default_file: path.resolve(cwd, '' + path.join(cwd, 'www') + '/index.html'),
     project_dir: cwd,
     www_root: path.resolve(path.join(cwd, 'www')),
-    admin_root: path.resolve(cwd + hoodie_admin_dashboard_root),
+    admin_root: path.dirname(require.resolve('hoodie-admin-dashboard/www/index.html')),
     host: env.HOODIE_BIND_ADDRESS || '127.0.0.1',
     app: pkgfile,
     domain: 'dev',
@@ -172,4 +156,3 @@ exports.getConfig = function (platform, env, cwd, argv) {
 
   return env_config;
 };
-

--- a/lib/core/environment.js
+++ b/lib/core/environment.js
@@ -6,9 +6,9 @@
 
 var url = require('url');
 var path = require('path');
-var ports = require('ports');
+
 var _ = require('lodash');
-var path = require('path');
+var ports = require('ports');
 
 var utils = require('../utils');
 var couchUtils = require('../utils/couch');
@@ -18,6 +18,7 @@ var couchUtils = require('../utils/couch');
  */
 
 exports.getConfig = function (platform, env, cwd, argv) {
+  cwd = path.resolve(cwd);
 
   // location of project's package.json
   var pkgfile = require(cwd + '/package.json');
@@ -25,54 +26,49 @@ exports.getConfig = function (platform, env, cwd, argv) {
   // default platform-agnostic config
   var env_config = {
     is_in_app: !/hoodie-server$/.test(cwd),
-    default_file: path.resolve(cwd, '' + path.join(cwd, 'www') + '/index.html'),
+    default_file: path.join(cwd, 'www', 'index.html'),
     project_dir: cwd,
-    www_root: path.resolve(path.join(cwd, 'www')),
+    www_root: path.join(cwd, (argv.www || argv.w || 'www')),
     admin_root: path.dirname(require.resolve('hoodie-admin-dashboard/www/index.html')),
     host: env.HOODIE_BIND_ADDRESS || '127.0.0.1',
     app: pkgfile,
     domain: 'dev',
-    verbose: false,
-    local_tld: undefined,
+    verbose: argv.verbose || argv.v,
+    local_tld: argv['local-tld'],
     platform: platform,
     boring: false, // turn off fancy terminal stuff where possible
     id: pkgfile.name,
     // add Hoodie paths to config
     hoodie: {
       env: env,
-      app_path: path.resolve(cwd),
-      data_path: path.resolve(path.join(cwd, 'data'))
+      app_path: cwd,
+      data_path: path.join(cwd, 'data')
     },
     couch: couchUtils.getCouch(env),
     open_browser: env.CI ? false : true
   };
 
-  // option to set server root url
-  if (argv.hasOwnProperty('www') || argv.hasOwnProperty('w')) {
-    env_config.www_root = path.resolve(cwd + '/' + (argv.www || argv.w));
-  }
-
-  if (argv.hasOwnProperty('verbose') || argv.hasOwnProperty('v')) {
-    env_config.verbose = true;
-  }
-
   // option to configure custom ports
   if (argv.hasOwnProperty('custom-ports')) {
-    var c_ports = argv['custom-ports'].split(',').reduce(function (memo, port) {
-      port = parseInt(port, 10);
-      if (port > 0) {
-        memo.push(port);
-      }
-      return memo;
-    }, []);
-    if (c_ports.length === 3) {
-      env_config.www_port = c_ports[0];
-      env_config.admin_port = c_ports[1];
-      env_config.couch.port = c_ports[2];
-    } else {
+    var c_ports = _(argv['custom-ports'].split(','))
+    .map(function (port) {
+      return parseInt(port.trim(), 10);
+    })
+    .compact()
+    .filter(function (port) {
+      return port > 0;
+    })
+    .uniq()
+    .value();
+
+    if (c_ports.length !== 3) {
       throw new Error('custom-ports option must contain 3 ports separated by ' +
                       'commas, ie: --custom-ports 7777,8888,9999');
     }
+
+    env_config.www_port = c_ports[0];
+    env_config.admin_port = c_ports[1];
+    env_config.couch.port = c_ports[2];
   } else {
     env_config.www_port = ports.getPort(env_config.id + '-www');
     env_config.admin_port = ports.getPort(env_config.id + '-admin');
@@ -86,11 +82,6 @@ exports.getConfig = function (platform, env, cwd, argv) {
     return env_config.local_tld ? env_config.admin_local_url
       : 'http://' + env_config.host + ':' + env_config.admin_port;
   };
-
-  // option to turn on/off local-tld on command-line
-  if (argv.hasOwnProperty('local-tld')) {
-    env_config.local_tld = argv['local-tld'];
-  }
 
   // do magic firewall stuff for .dev domains on mac
   if (platform === 'darwin') {
@@ -143,7 +134,6 @@ exports.getConfig = function (platform, env, cwd, argv) {
   if (env.HOODIE_SETUP_PASSWORD) {
     env_config.admin_password = env.HOODIE_SETUP_PASSWORD;
   }
-
 
   if (!env_config.couch.url) {
     env_config.couch.url = 'http://' + env_config.host + ':' + env_config.couch.port;

--- a/lib/core/environment.js
+++ b/lib/core/environment.js
@@ -25,7 +25,6 @@ exports.getConfig = function (platform, env, cwd, argv) {
 
   // default platform-agnostic config
   var env_config = {
-    is_in_app: !/hoodie-server$/.test(cwd),
     default_file: path.join(cwd, 'www', 'index.html'),
     project_dir: cwd,
     www_root: path.join(cwd, (argv.www || argv.w || 'www')),

--- a/lib/core/plugins.js
+++ b/lib/core/plugins.js
@@ -4,7 +4,6 @@
 
 var plugins_manager = require('hoodie-plugins-manager/lib/index');
 var clc = require('cli-color');
-var modulelib = require('module');
 var async = require('async');
 var path = require('path');
 var fs = require('fs');
@@ -140,43 +139,36 @@ exports.isDirectory = function (p) {
 };
 
 exports.resolvePluginPath = function (env_config, p) {
-  var dir;
+  var errorMessage = 'Plugin not found: ' + p;
 
-  if (p[0] === '.' || p[0] === '/') {
-    // relative or absolute path
-    dir = path.resolve(env_config.project_dir, p);
-    if (exports.isDirectory(dir)) {
-      return dir;
-    }
-  } else {
-    // module lookup
-    var id = path.resolve(env_config.project_dir, 'package.json');
-    var m = new modulelib.Module(id);
-    var paths = modulelib.Module._resolveLookupPaths('./blah', m)[1];
-
-    for (var i = 0; i < paths.length; i++) {
-      dir = path.resolve(paths[i], p);
-      if (exports.isDirectory(dir)) {
-        return dir;
-      }
+  // module lookup
+  if (!(p[0] === '.' || p[0] === '/')) {
+    try {
+      return path.dirname(require.resolve(p + '/package.json'));
+    } catch (e) {
+      throw new Error(errorMessage);
     }
   }
-  throw new Error('Plugin not found: ' + p);
+
+  // relative or absolute path
+  var dir = path.resolve(env_config.project_dir, p);
+  if (exports.isDirectory(dir)) {
+    return dir;
+  }
+  throw new Error(errorMessage);
 };
 
 exports.getPluginPaths = function (env_config) {
   var app = env_config.app;
 
-  if (!app.hoodie) {
-    app.hoodie = {};
-  }
+  app.hoodie = app.hoodie || {};
 
   if (!app.hoodie.plugins) {
+    app.hoodie.plugins = [];
     console.log(clc.yellow(
       'WARNING: No hoodie.plugins property in package.json, ' +
       'no plugins will be loaded!'
     ));
-    app.hoodie.plugins = [];
   }
 
   return app.hoodie.plugins.map(function (p) {

--- a/lib/server/plugins/api/index.js
+++ b/lib/server/plugins/api/index.js
@@ -1,12 +1,13 @@
-var _ = require('lodash');
 var path = require('path');
+
+var _ = require('lodash');
 var Wreck = require('wreck');
 
 var hoodiejs = require('../../../helpers/pack_hoodie');
 var plugins = require('../../../helpers/plugin_api');
 
 var internals = {
-  uiKitPath: '/node_modules/hoodie-server/node_modules/hoodie-admin-dashboard-uikit/dist/',
+  uiKitPath: path.dirname(require.resolve('hoodie-admin-dashboard-uikit/dist/index.html')),
   mapProxyPath: function (request, callback) {
     //use the bearer token as the cookie AuthSession for couchdb:
     if (request.headers.authorization && request.headers.authorization.substring(0, 'Bearer '.length) === 'Bearer ') {
@@ -260,16 +261,7 @@ exports.register = function (plugin, options, next) {
       path: '/_api/_plugins/_assets/{path*}',
       handler: {
         directory: {
-          path: function () {
-            var projectDir = options.app.project_dir;
-            var uiKitPath = internals.uiKitPath;
-            if (!options.app.is_in_app) {
-              // we are running inside hoodie-server, e.g. in dev and test mode
-              uiKitPath = uiKitPath.replace('/node_modules/hoodie-server', '');
-            }
-            var p = path.join(projectDir, uiKitPath);
-            return p;
-          },
+          path: internals.uiKitPath,
           listing: true,
           index: false
         }

--- a/lib/server/plugins/api/index.js
+++ b/lib/server/plugins/api/index.js
@@ -271,20 +271,6 @@ exports.register = function (plugin, options, next) {
       method: 'GET',
       path: '/_api/_files/hoodie.js',
       handler: internals.getHoodiePath
-    },
-    {
-      method: 'GET',
-      path: '/_api/_files/force-gzip.html',
-      handler: function (request, reply) {
-        var projectDir = options.app.project_dir;
-        var internalFilePath = 'node_modules/hoodie-server/lib/assets/force-gzip.html';
-        if (!options.app.is_in_app) {
-          // we are running inside hoodie-server, e.g. in dev and test mode
-          internalFilePath = internalFilePath.replace('node_modules/hoodie-server', '');
-        }
-        var finalFilePath = path.join(projectDir, internalFilePath);
-        reply.file(finalFilePath);
-      }
     }
   ]);
 


### PR DESCRIPTION
Ready for review now. Please not only look at the files, but test it locally installing this branch in a local hoodie-app, because it touches quite some stuff. Read my comments on specific lines and commit message (bodies) for further explanation.

```
hoodie new myapp
cd myapp
n i -S hoodiehq/hoodie-server#fix-require-resolve-usage
hoodie start
```

As the title suggests I've tried to replace all code that tries to predict the location of a dependency's file on the disk, by assuming it's in `node_modules`, with the "the proper way™": `require.resolve`.

As things often are when you do them "the proper way™" this removes a lot of complexity and code, which looks intriguing, but please make sure in your review that it still behaves the same.
