### PR TITLE
resolvePluginPath even if hoodie-server is npm linked

### DIFF
--- a/lib/core/plugins.js
+++ b/lib/core/plugins.js
@@ -144,9 +144,23 @@ exports.resolvePluginPath = function (env_config, p) {
   // module lookup
   if (!(p[0] === '.' || p[0] === '/')) {
     try {
-      return path.dirname(require.resolve(p + '/package.json'));
+      return path.dirname(require.resolve(path.join(p, 'package.json')));
     } catch (e) {
-      throw new Error(errorMessage);
+      if (e.code !== 'MODULE_NOT_FOUND') {
+        throw new Error(errorMessage);
+      }
+
+      // hoodie-server might be `npm link`ed. Let's retry in the cwd.
+      try {
+        return path.dirname(require.resolve(path.join(
+          env_config.cwd,
+          'node_modules',
+          p,
+          'package.json'
+        )));
+      } catch(e) {
+        throw new Error(errorMessage);
+      }
     }
   }
 


### PR DESCRIPTION
As pointed out by @janl again in #354 `require.resolve` won't find plugins if hoodie-server is `npm link`ed.
Actually we had an integration test for this, but I just "fixed" the tests, rather than the bug :speak_no_evil: 

1. [x] Revert Integration Test https://github.com/hoodiehq/hoodie-integration-test/commit/e344686ed76f50fd2e3bd398fceabb6daf4b9ed5
2. [x] Find plugins even if hoodie-server is `npm link`ed (this PR)
3. [x] Let this PR successfully run against new/old integration tests