### PR TITLE
resolvePluginPath if hoodie-server is npm linked

### DIFF
--- a/lib/core/plugins.js
+++ b/lib/core/plugins.js
@@ -153,7 +153,7 @@ exports.resolvePluginPath = function (env_config, p) {
       // hoodie-server might be `npm link`ed. Let's retry in the cwd.
       try {
         return path.dirname(require.resolve(path.join(
-          env_config.cwd,
+          env_config.project_dir,
           'node_modules',
           p,
           'package.json'


### PR DESCRIPTION
a.k.a the commit that b7408e248d250ac2ec48ac716253fedb2984b770/#357 should've been
