### PR TITLE
Updated nodemailer to version 1.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "lodash": "3.10.1",
     "mkdirp": "0.5.1",
     "moment": "2.10.6",
-    "nodemailer": "1.5.0",
+    "nodemailer": "1.6.0",
     "npmlog": "1.2.1",
     "ports": "1.1.0",
     "random-string": "0.1.2",


### PR DESCRIPTION
:rocket:

nodemailer just published version 1.6.0, so that’s now up to date in your `package.json`.

Check that it doesn’t break your code and release the new version of your software safe in the knowledge that it will stay in this working state.

---
The new version differs by 1 commits (ahead by 1, behind by 0).

- [529a8c9](https://github.com/andris9/Nodemailer/commit/529a8c92c2cda2d810410fc6406e07576ddde290): Bumped version to v1.6.0

See the [full diff](https://github.com/andris9/Nodemailer/compare/038ba918cbdbed59a4ef519c18527438b0019f4c...529a8c92c2cda2d810410fc6406e07576ddde290).