### PR TITLE
Updated inert to version 3.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "hapi": "9.3.1",
     "hapi-couchdb-account": "1.0.0",
     "hapi-couchdb-store": "1.1.1",
-    "inert": "3.0.2",
+    "inert": "3.1.0",
     "lodash": "3.10.1",
     "mkdirp": "0.5.1",
     "moment": "2.10.6",


### PR DESCRIPTION
:rocket:

inert just published version 3.1.0, so that’s now up to date in your `package.json`.

Check that it doesn’t break your code and release the new version of your software safe in the knowledge that it will stay in this working state.

---
The new version differs by 6 commits (ahead by 6, behind by 0).

- [c4c0772](https://github.com/hapijs/inert/commit/c4c077282463adf0c915d492b50c4887d6053c4d): 3.1.0
- [ae8cd8e](https://github.com/hapijs/inert/commit/ae8cd8e2de72c6c8f84cbd36e138321f2fae0254): Apply new plugin attributes. Closes #43
- [e21b098](https://github.com/hapijs/inert/commit/e21b09829e51cf3b332a81acd368d4004fd08067): Update to lab@6.x
- [4a54ac0](https://github.com/hapijs/inert/commit/4a54ac0ef08440e0207347db77ba6c7ba970caf8): Update lru-cache to 2.7.x
- [cbbf556](https://github.com/hapijs/inert/commit/cbbf55679c8eff36e8ff60c03f4058b0d59652be): Ensure a compatible version of joi is installed
- [9911f4d](https://github.com/hapijs/inert/commit/9911f4d715910f21ce9b9520cfa2f3ad0bd3b0bd): Test using hapi-lts@10.x whenever possible. Closes #44

See the [full diff](https://github.com/hapijs/inert/compare/a65c7317e14d150e98b2e7b201926b15cc723dcb...c4c077282463adf0c915d492b50c4887d6053c4d).