### PR TITLE
Proposal: Moving forward require at least Node v4 for Hoodie apps

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,19 +6,9 @@ cache:
 notifications:
   email: false
 node_js:
-- iojs-v2
-- iojs-v1
-- '0.12'
-- '0.10'
-before_install:
-- npm i -g npm@^2.0.0
-install:
-- npm install --no-optional
+- 4
 before_script:
 - npm prune
-- curl -Lo travis_after_all.py https://git.io/vLSON
 after_success:
 - npm run coverage:upload
-- python travis_after_all.py
-- export $(cat .to_export_back)
 - npm run semantic-release

--- a/package.json
+++ b/package.json
@@ -12,10 +12,10 @@
     "good": "^6.4.0",
     "good-squeeze": "^2.1.0",
     "h2o2": "^4.0.1",
-    "hapi": "^9.3.1",
+    "hapi": "^10.4.1",
     "hapi-couchdb-account": "^1.0.0",
     "hapi-couchdb-store": "^1.1.1",
-    "inert": "^3.0.2",
+    "inert": "^3.1.0",
     "lodash": "^3.10.1",
     "mkdirp": "^0.5.1",
     "moment": "^2.10.6",
@@ -44,7 +44,7 @@
     "tap": "^2.1.1"
   },
   "engines": {
-    "node": ">=0.10.22"
+    "node": ">=4"
   },
   "homepage": "https://github.com/hoodiehq/hoodie-server",
   "keywords": [


### PR DESCRIPTION
~~Forced~~ Inspired by hapi's recent move to require a Node version of at least 4 to be run, I'm proposing the same for Hoodie.

> hapi v10.0.0 contains no breaking changes. It is published to indicate the transition from node v0.10 to node v4.0. Moving to v10.0.0 only requires upgrading your node version to the latest v4. Future releases of the hapi v10 branch will include internal changes to take advantage of the new features available in node v4 and those will break under node v0.10.

> Upgrade time: low - a couple of hours for most users for running tests
Complexity: low - no code changes to existing hapi v9 users
Risk: moderate - care should be taken moving to a new version of node for non-hapi code
Dependencies: low - just node v4

> – [10.0.0 release notes](https://github.com/hapijs/hapi/issues/2764)

This makes sense for very pragmatic reasons. Hapi is one of Hoodie's biggest and most important dependencies. Turning away from their ways will come with lots of pain and maintenance cost and it slows us and the entire ecosystem down (already).
They're offering an lts (long term support) version for hapi@9, but I think it wasn't at a very high priority when making the decision to move on to node v4. It's something people can (or rather must) use who're consuming hapi directly and can't upgrade their apps yet – for other reasons. It has some special requirements like using npm@3 and it isn't fully clear yet how it stays compatible with the hapi ecosystem (They might publish every single plugin again as *-lts, for example). Hapi-lts isn't something they fully built before making the change and then went on, but something they add(ed) later.

Both in the interest of the people we're hiding hapi away from and the people who want to extend Hoodie using server hooks, it's a desirable thing to be on the latest version and to expose full functionality.

All this comes with the speed improvements of node v4, with [new language features](https://nodejs.org/en/docs/es6/) and with reduced testing time (just one build) and ultimately faster development speed.

I think with the groundbreaking changes we already applied to Hoodie in the past weeks this is a rather small thing to ask for in comparison. Node 0.10 will soon loose official support and given that there is quite some work involved before we can get Hoodie out ourselves the time difference might not even be that much. This is a move we'll be making sooner or later anyway, so we might as well benefit from it.

If someone wants to (or has to) run hoodie on 0.10 we can let this be figured out by the community or build it back in at a later time. I don't think we're in a position where we can task ourselves with any more development burdens that complicate our very own 1.0 release.

Closes #398, Closes #396