### PR TITLE
Enable account component

### DIFF
--- a/lib/couchdb.js
+++ b/lib/couchdb.js
@@ -16,11 +16,18 @@ var exports = module.exports = function (config, callback) {
     json: true
   })
 
-  async.waterfall([
+  async.series([
     async.apply(exports.checkVendor, config, couch),
     async.apply(exports.setConfig, couch),
-    async.apply(exports.getConfig, couch)
-  ], callback)
+    async.apply(exports.getConfig, couch),
+    async.apply(exports.getAdmins, couch)
+  ], function (err, results) {
+    if (err) return callback(err)
+
+    callback(null, _.assign({
+      admins: results[3]
+    }, results[2]))
+  })
 }
 
 exports.generatedConfig = function generatedConfig (config) {
@@ -42,7 +49,8 @@ exports.generatedConfig = function generatedConfig (config) {
 
   return {
     secret: secret,
-    authentication_db: '_users'
+    authentication_db: '_users',
+    admins: {}
   }
 }
 
@@ -100,5 +108,17 @@ exports.getConfig = function getConfig (couch, callback) {
     }
 
     callback(null, _.pick(data, ['secret', 'authentication_db']))
+  })
+}
+
+exports.getAdmins = function getAdmins (couch, callback) {
+  couch({
+    url: '/_config/admins'
+  }, function (err, res, data) {
+    if (err || (res && res.statusCode !== 200)) {
+      return callback(new Error('Could not retrieve CouchDB admins'))
+    }
+
+    callback(null, data)
   })
 }

--- a/lib/hapi.js
+++ b/lib/hapi.js
@@ -1,37 +1,32 @@
-// var _ = require('lodash')
-// var PouchDB = require('pouchdb')
+module.exports = function (config, usersDbName, callback) {
+  var database = require('./database')(config)
+  var usersDb = database(usersDbName)
 
-module.exports = function (config, usersDb, callback) {
-  // var users = new PouchDB(usersDb)
-  // users.plugin(require('pouchdb-users'))
-  // users.installUsersBehavior()
-  // .then(function () {
-  //   var defaultOpts = {
-  //     config: config,
-  //     database: require('./database')(config),
-  //     prefix: '/hoodie/account',
-  //     users: users
-  //   }
-  //
-  //   // insert below code here
-  // }, callback)
+  usersDb.constructor.plugin(require('pouchdb-users'))
 
-  callback(null, [
-    require('inert'),
-    require('h2o2')
-  ].concat([
-    require('./static'),
-    require('./http-log')
-  ].map(function (plugin) {
-    return {
-      register: plugin,
-      options: {config: config}
-    }
-  })/*, [{
-    register: require('@hoodie/server-account-node-sessions'),
-    options: defaultOpts
-  }, {
-    register: require('hoodie-server-store'),
-    options: _.defaults({prefix: '/hoodie/store'}, defaultOpts)
-  }]*/))
+  usersDb.installUsersBehavior().then(function () {
+    var options = {config, usersDb}
+
+    var hapiPlugins = [
+      require('h2o2'),
+      require('inert')
+    ]
+
+    var localPlugins = [
+      require('./http-log'),
+      require('./static')
+    ].map(function (register) { return {options, register} })
+
+    var hoodieCorePlugins = [{
+      options,
+      register: require('hoodie-server-account'),
+      routes: {prefix: '/hoodie/account'}
+    // }, {
+    //   options,
+    //   register: require('hoodie-server-store'),
+    //   routes: {prefix: '/hoodie/store'}
+    }]
+
+    callback(null, hapiPlugins.concat(localPlugins, hoodieCorePlugins))
+  }, callback)
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -15,6 +15,7 @@ module.exports = function (options, callback) {
     if (err) return callback(err)
 
     config.db.secret = couchConfig.secret
+    config.db.admins = couchConfig.admins
 
     server.connection({
       host: config.app.hostname,

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "good-squeeze": "^2.1.0",
     "h2o2": "^5.0.0",
     "hapi": "^11.0.3",
+    "hoodie-server-account": "^2.1.0",
     "hoodie-server-store": "^1.0.1",
     "inert": "^3.1.0",
     "jsonfile": "^2.2.3",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
     "url": "https://github.com/hoodiehq/hoodie-server/issues"
   },
   "dependencies": {
-    "@hoodie/server-account-node-sessions": "^1.0.0",
     "async": "^1.5.0",
     "good": "^6.4.0",
     "good-squeeze": "^2.1.0",
@@ -20,10 +19,9 @@
     "memdown": "^1.1.0",
     "mkdirp": "^0.5.1",
     "my-first-hoodie": "^4.0.0",
-    "nock": "^3.4.0",
     "npmlog": "^2.0.0",
     "pouchdb": "^5.1.0",
-    "pouchdb-users": "^1.0.0",
+    "pouchdb-users": "^1.0.3",
     "randomstring": "^1.1.3",
     "request": "^2.65.0",
     "require-relative": "^0.8.7"

--- a/test/unit/couchdb.js
+++ b/test/unit/couchdb.js
@@ -27,7 +27,7 @@ test('init couchdb', function (t) {
 
     t.is(result.secret, 'foo')
     t.is(result.authentication_db, '_users')
-    t.equals(result.admins, {
+    t.same(result.admins, {
       user: 'secret'
     })
 

--- a/test/unit/couchdb.js
+++ b/test/unit/couchdb.js
@@ -14,6 +14,11 @@ nock('http://127.0.0.1:5984')
     authentication_db: '_users'
   })
 
+  .get('/_config/admins')
+  .reply(200, {
+    user: 'secret'
+  })
+
 test('init couchdb', function (t) {
   var couchdb = require('../../lib/couchdb')
 
@@ -22,6 +27,9 @@ test('init couchdb', function (t) {
 
     t.is(result.secret, 'foo')
     t.is(result.authentication_db, '_users')
+    t.equals(result.admins, {
+      user: 'secret'
+    })
 
     t.end()
   })

--- a/test/unit/couchdb/get-admins.js
+++ b/test/unit/couchdb/get-admins.js
@@ -1,0 +1,47 @@
+var test = require('tap').test
+
+test('get couch admins', function (t) {
+  t.test('request fails', function (tt) {
+    var getAdmins = require('../../../lib/couchdb.js').getAdmins
+
+    tt.plan(2)
+
+    getAdmins(function (input, callback) {
+      callback(new Error())
+    }, function (err) {
+      tt.ok(err instanceof Error)
+    })
+
+    getAdmins(function (input, callback) {
+      callback(null, {statusCode: 500})
+    }, function (err) {
+      tt.ok(err instanceof Error)
+    })
+  })
+
+  t.test('request succeds', function (tt) {
+    var getAdmins = require('../../../lib/couchdb.js').getAdmins
+
+    tt.plan(5)
+
+    getAdmins(function (input, callback) {
+      tt.is(input.url, '/_config/admins')
+      callback(null, null, {})
+    }, function (err) {
+      tt.ok(err instanceof Error)
+    })
+
+    getAdmins(function (input, callback) {
+      tt.is(input.url, '/_config/admins')
+      callback(null, null, {
+        user: 'secret'
+      })
+    }, function (err, admins) {
+      tt.error(err)
+
+      tt.is(admins.user, 'secret')
+    })
+  })
+
+  t.end()
+})

--- a/test/unit/couchdb/get-admins.js
+++ b/test/unit/couchdb/get-admins.js
@@ -22,15 +22,6 @@ test('get couch admins', function (t) {
   t.test('request succeds', function (tt) {
     var getAdmins = require('../../../lib/couchdb.js').getAdmins
 
-    tt.plan(5)
-
-    getAdmins(function (input, callback) {
-      tt.is(input.url, '/_config/admins')
-      callback(null, null, {})
-    }, function (err) {
-      tt.ok(err instanceof Error)
-    })
-
     getAdmins(function (input, callback) {
       tt.is(input.url, '/_config/admins')
       callback(null, null, {
@@ -40,6 +31,7 @@ test('get couch admins', function (t) {
       tt.error(err)
 
       tt.is(admins.user, 'secret')
+      tt.end()
     })
   })
 


### PR DESCRIPTION
_(This is what #434 should have been.)_

1. extracts the admins from the CouchDB config
2. passes admins into plugins **directly** inside hoodie config (as far as I understood this should only be temporary, and pass the pouchdb-admins instance in the future)

---

Before this is can get merged I'd appreciate some clarity, because there seem to be a leat a few concepts of what the config passed to components looks like. Here is my understanding:

1. All components get the same object/data, clear expectations inside components, no special treatment. 
2. Under `options.config` is the hoodie config
3. APIs are passed in options directly, (database, usersDb, (admins)), but no other config/data
4. this is what might end up being our new plugins api, special care/treatment and stability appreciated

There were a few different approaches in #434. Most importantly though hoodie-server-account doesn't make use of the config object at all, but expects everything on top-level: https://github.com/hoodiehq/hoodie-server-account/blob/master/plugin/index.js#L21-L49

Should we want to initialize `pouchdb-admins` inside hoodie-server again, it can then be passed on `options.admins` (or similar), and no longer inside config. (Breaking Change)