### PR TITLE
fix: don’t accidentally leak credentials

### DIFF
--- a/lib/config/assure-folders.js
+++ b/lib/config/assure-folders.js
@@ -2,6 +2,7 @@ module.exports = assureFolders
 
 var parallel = require('async').parallel
 var mkdirp = require('mkdirp')
+var url = require('url')
 
 function assureFolders (state, callback) {
   if (state.inMemory) {
@@ -11,7 +12,11 @@ function assureFolders (state, callback) {
   var tasks = [
     mkdirp.bind(null, state.config.paths.data)
   ]
-  if (state.db.options.prefix) {
+
+  // if the prefix has a protocol like 'http', we assume that this is an external
+  // prefix and we don't create the local folder to prevent accidental credential
+  // leakage
+  if (state.db.options.prefix && !url.parse(state.db.options.prefix).protocol) {
     tasks.push(mkdirp.bind(null, state.db.options.prefix))
   }
 

--- a/test/unit/assure-folders-test.js
+++ b/test/unit/assure-folders-test.js
@@ -55,5 +55,32 @@ test('assure config folders', function (group) {
     })
   })
 
+  group.test('with config.db.prefix that is an url', function (t) {
+    var mkdirpMock = simple.stub().callbackWith(null)
+    var assureFolders = proxyquire('../../lib/config/assure-folders', {
+      mkdirp: mkdirpMock
+    })
+
+    assureFolders({
+      config: {
+        paths: {
+          data: 'data path'
+        }
+      },
+      db: {
+        options: {
+          prefix: 'http://admin:admin@localhost:5984'
+        }
+      }
+    }, function (error) {
+      t.error(error)
+
+      t.is(mkdirpMock.callCount, 1, 'mkdirp called once')
+      t.is(mkdirpMock.lastCall.arg, 'data path', 'db prefix path created')
+
+      t.end()
+    })
+  })
+
   group.end()
 })


### PR DESCRIPTION
While testing something out, I noticed that the current code creates a local folder with the prefix even tho it contains credentials:

![](https://cloud.githubusercontent.com/assets/82050/17933054/e2deee4a-6a12-11e6-804d-e7dc86522ffa.png)

I really don't know why you create a folder for the prefix, so there might be a whole other reasoning behind it that I simply don't get yet (hoodie is still new-ish to me), so feel free to ignore all of this :)