### PR TITLE
POST db/_all_docs is just a read

### DIFF
--- a/lib/config/store/pre-auth-hook.js
+++ b/lib/config/store/pre-auth-hook.js
@@ -22,7 +22,7 @@ function onStorePreAuth (request, reply) {
   var storePath = request.path.substr('/hoodie/store/api/'.length)
   var dbPath = storePath.split('/')[0]
   var dbName = decodeURIComponent(dbPath)
-  var requiredAccess = request.method === 'get' ? 'read' : 'write'
+  var requiredAccess = isRead(request) ? 'read' : 'write'
 
   return server.plugins.store.api.hasAccess(dbName, {
     access: requiredAccess
@@ -77,4 +77,17 @@ function toSessionToken (request) {
     token = request.headers.authorization.substring('Session '.length)
   }
   return token
+}
+
+function isRead (request) {
+  if (request.method === 'get') {
+    return true
+  }
+
+  // POST db/_all_docs is still a read request
+  if (/^\/hoodie\/store\/api\/[^\/]+\/_all_docs$/.test(request.path)) {
+    return true
+  }
+
+  return false
 }


### PR DESCRIPTION
Currently the code only differentiates between GET & POST requests: GET means read, POST means write. But POST /db/_all_docs is a valid request, but still just a read, and turns out that PouchDB is using that request for read replications, so I’ll go ahead and merge this (tested it locally) because the current state is potentially broken.

But please review, I’ll do follow up PRs if I missed something