### PR TITLE
WIP: Fix promise errors with store preAuth hook

### DIFF
--- a/lib/config/store/pre-auth-hook.js
+++ b/lib/config/store/pre-auth-hook.js
@@ -15,7 +15,9 @@ function onStorePreAuth (request, reply) {
   // PouchDB’s replication sends an initial GET to CouchDB root initially
   var isGetRootPath = request.path === '/hoodie/store/api/' && request.method === 'get'
   if (isGetRootPath) {
-    return reply.continue()
+    return new Promise(function (resolve) {
+      resolve(reply.continue())
+    })
   }
 
   // check if store is publically accessable
@@ -30,12 +32,12 @@ function onStorePreAuth (request, reply) {
 
   .then(function (hasAccess) {
     if (hasAccess) {
-      return reply.continue()
+      return throwContinue('You have permissions for DB access')
     }
 
     var sessionToken = toSessionToken(request)
     if (!sessionToken) {
-      return reply(Boom.unauthorized())
+      return throwUnauthorized('No session token given')
     }
 
     return server.plugins.account.api.sessions.find(sessionToken)
@@ -51,19 +53,23 @@ function onStorePreAuth (request, reply) {
       access: requiredAccess,
       role: roles
     })
+  })
 
-    .then(function (hasAccess) {
-      if (hasAccess) {
-        return reply.continue()
-      }
+  .then(function (hasAccess) {
+    if (hasAccess) {
+      return throwContinue('Given session has permissions for DB access')
+    }
 
-      reply(Boom.unauthorized())
-    })
+    return throwUnauthorized('No access to database at requested level with given roles')
   })
 
   .catch(function (error) {
-    if (error.status === 404) { // session not found
+    if (error.status === 404 || error.status === 401) { // session not found
       return reply(Boom.unauthorized())
+    }
+
+    if (error.status === 201) { // continue
+      return reply.continue()
     }
 
     server.log(['store', 'error'], error.message)
@@ -90,4 +96,18 @@ function isRead (request) {
   }
 
   return false
+}
+
+function throwContinue (message) {
+  throwResponse(message, 201)
+}
+
+function throwUnauthorized (message) {
+  throwResponse(message, 401)
+}
+
+function throwResponse (message, errorCode) {
+  var response = new Error(message)
+  response.status = errorCode
+  throw response
 }


### PR DESCRIPTION
As part of this make the preAuthHook function always return a Promise (like it's doing most of the time currently) And in doing so, take advantage of node-tap's Promise handling.

Closes #524 
