### PR TITLE
Prevent unhandledpromiserejection warning

### DIFF
--- a/test/unit/config/store-pre-auth-hook-test.js
+++ b/test/unit/config/store-pre-auth-hook-test.js
@@ -102,7 +102,7 @@ test('store pre auth hook root path', function (t) {
 
 // TODO: this test causes a UnhandledPromiseRejectionWarning and I dunno why
 test('store pre auth hook no authorization header', function (t) {
-  var findSessionStub = simple.stub().rejectWith({status: 404})
+  var findSessionStub = simple.stub()
   var hasAccessStub = simple.stub().resolveWith(false)
   var serverStub = {
     log: simple.stub(),


### PR DESCRIPTION
The defined behaviour below is never called, and therefore the defined promise rejection is never handled, resulting in [an UnhandledPromiseRejection warning on later versions of NodeJS](jupiter/simple-mock#22) when the test suite is run. This merge request fixes this issue.