### PR TITLE
feat: debloat package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,13 +47,11 @@
     "boom": "^4.2.0",
     "h2o2": "^5.1.0",
     "inert": "^4.0.1",
-    "jsonfile": "^2.3.1",
     "lodash": "^4.14.1",
     "pouchdb-admins": "^1.0.3",
     "pouchdb-doc-api": "^1.0.1",
     "randomstring": "^1.1.5",
     "request": "^2.80.0",
-    "strip-url-auth": "^1.0.1",
     "vision": "^4.1.0"
   }
 }


### PR DESCRIPTION
Hi,

Thanks for developing this good project, which provides high-coverage tests.

I'm doing dynamic analysis on npm packages, and your project is one of my samples.

Through our dynamic analysis by running the test suites, we find that 2 of the runtime dependencies are installed, however, they are not used during test runtime. We removed these dependencies from package.json, and installed the remaining dependencies, the tests all passed.

Would you consider creating a slim version of the package.json, which can help reduce the corresponding maintenance costs and security risks in production?